### PR TITLE
Remove warning for unused props using react 15

### DIFF
--- a/src/tappable.jsx
+++ b/src/tappable.jsx
@@ -196,6 +196,9 @@ let Tappable = React.createClass({
         delete newComponentProps.preventDefault;
         delete newComponentProps.stopPropagation;
         delete newComponentProps.component;
+        delete newComponentProps.flickThreshold;
+        delete newComponentProps.delta;
+        delete newComponentProps.handlers;
 
         return React.createElement(props.component, newComponentProps, props.children)
     }


### PR DESCRIPTION
This may be something that you want to do. This surely will help my group who uses your react-month-picker out. Thanks!

* removed unused props: flickThreshold, delta, and handlers from component in order to prevent warning messages in console 

This fixes issue #1  